### PR TITLE
Use anonymous github repository for queue.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if(SMARTPTR_ENABLE_BENCHMARK)
 endif()
 
 FetchContent_Declare(queue
-    GIT_REPOSITORY git@github.com:romanpauk/queue.git
+    GIT_REPOSITORY https://github.com/romanpauk/queue.git
     GIT_TAG develop)
 
 set(QUEUE_ENABLE_TESTING OFF)


### PR DESCRIPTION
-- Performing Test HAVE_STEADY_CLOCK -- success
The authenticity of host 'github.com (140.82.121.3)' can't be established.
ED25519 key fingerprint is SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
[ 11%] Creating directories for 'queue-populate'
[ 22%] Performing download step (git clone) for 'queue-populate'
Cloning into 'queue-src'...
Warning: Permanently added 'github.com' (ED25519) to the list of known hosts.
no such identity: /home/azul/.ssh/id_dsa: No such file or directory
no such identity: /home/azul/.ssh/identity: No such file or directory
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.